### PR TITLE
fix: path 导致的 dashboard 无法获取 cookie

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -229,8 +229,6 @@ export class Server {
         
                 res.cookie('token', token, {
                     expires: new Date(Date.now() + 86400000), // 24小时后过期
-                    secure: true,
-                    path: '/'
                 });
 
                 if (this.db.getEntity<UserEntity>(UserEntity, user.id)?.isSuperUser) {
@@ -240,8 +238,6 @@ export class Server {
                     }, "admin", 60 * 60 * 24);
                     res.cookie('adminToken', adminToken, {
                         expires: new Date(Date.now() + 86400000), // 24小时后过期
-                        secure: true,
-                        path: '/'
                     });
                 }
         

--- a/src/server.ts
+++ b/src/server.ts
@@ -230,7 +230,7 @@ export class Server {
                 res.cookie('token', token, {
                     expires: new Date(Date.now() + 86400000), // 24小时后过期
                     secure: true,
-                    path: '/93AtHome'
+                    path: '/'
                 });
 
                 if (this.db.getEntity<UserEntity>(UserEntity, user.id)?.isSuperUser) {
@@ -241,7 +241,7 @@ export class Server {
                     res.cookie('adminToken', adminToken, {
                         expires: new Date(Date.now() + 86400000), // 24小时后过期
                         secure: true,
-                        path: '/93AtHome/super'
+                        path: '/'
                     });
                 }
         


### PR DESCRIPTION
由于 Token 的 Cookie 设置的 Path 为/93AtHome , 作为前端 dashboard 无法读取 Cookie 是否存在，并且 Cookie 中的 Path 不能设置两层路径，所以建议删除 secure
在浏览器中 Cookie 只会在相同域名下转递，在当前不考虑 XSS 攻击的情况下，并不需要考虑 Cookie 安全性