### PR TITLE
删除 .npmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ database.sqlite
 /assets
 /plugins
 /plugin-dependencies/node_modules
+
+.npmrc

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/


### PR DESCRIPTION
此文件会导致包管理器全部将流量定向到官方源，严重拖慢构建速度